### PR TITLE
fix: viewholder takes up whole width

### DIFF
--- a/app/src/main/res/layout/fragment_week_overview.xml
+++ b/app/src/main/res/layout/fragment_week_overview.xml
@@ -8,7 +8,7 @@
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/weekdayListRecyclerView"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/weekday_list_item.xml
+++ b/app/src/main/res/layout/weekday_list_item.xml
@@ -20,7 +20,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         tools:text="08/07/2022"
-        app:layout_constraintStart_toEndOf="@id/weekday_list_item_day"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
         android:layout_margin="16dp"/>


### PR DESCRIPTION
This fixes: #28 

layout_width: wrap_content -> match_parent
Also updated the date of a weekday to have a constraint to the right of the viewholder